### PR TITLE
Hybrid authentication definition

### DIFF
--- a/input/mobile-device.xml
+++ b/input/mobile-device.xml
@@ -305,8 +305,8 @@ How is it differenet then me using subsection?
       <term abbr="HMAC" full="Keyed-Hash Message Authentication Code"/>
       <term abbr="HTTPS" full="HyperText Transfer Protocol Secure"/>
       <term full="Hybrid Authentication"> A hybrid authentication factor is one where a user has to
-        submit a combination of biometric sample and PIN or password with both to pass and without
-        the user being made aware of which factor failed, if either fails.</term>
+        submit a combination of biometric sample and PIN or password with both to pass and if 
+        either factor failed, the entire attempt fails.</term>
       <term full="Immutable Hardware Key"> These keys are stored as hardware-protected raw key and
         cannot be changed or sanitized.</term>
       <term abbr="IEEE" full="Institute of Electrical and Electronics Engineers"/>


### PR DESCRIPTION
This may be useful if both components are entered at the same time, but in many implementations it is a sequential authentication process, and if the first component entered is incorrect, the system does not allow the user to try the second entry. So for example, if the first component is the biometric and the user is unable to pass the biometric, they will not be prompted to enter the password.

It seems the real key here is that a failure of either is a failure to authenticate, not that both must be entered and the reason for the failure not reported.