### PR TITLE
remove "(While device is locked)"

### DIFF
--- a/input/mobile-device.xml
+++ b/input/mobile-device.xml
@@ -1683,7 +1683,7 @@ How is it differenet then me using subsection?
             </aactivity>
           </f-element>
         </f-component>
-        <f-component id="fcs_ckm.2" iteration="LOCKED" name="Cryptographic key establishment (While device is locked)">
+        <f-component id="fcs_ckm.2" iteration="LOCKED" name="Cryptographic key establishment">
           <f-element>
             <title>The TSF shall <refinement>perform</refinement> cryptographic <refinement>key
                 establishment</refinement> in accordance with a specified cryptographic key


### PR DESCRIPTION
now that the requirements are being iterated with labels, in this case "LOCKED" vs "UNLOCKED", the additional qualifier is no longer necessary. 

By comparison all the FCS_COP.1 requirements all just say "Cryptographic operation".