### PR TITLE
Assurance to Evaluation

### DIFF
--- a/input/mobile-device.xml
+++ b/input/mobile-device.xml
@@ -1786,7 +1786,7 @@ How is it differenet then me using subsection?
               <htm:br/><htm:br/> The RBG used to generate a REK may be a RBG native to the hardware
               key container or may be an off-device RBG. If performed by an off-device RBG, the
               device manufacturer shall not be able to access a REK after the manufacturing process
-              has been completed. The assurance activities for these two cases differ. </note>
+              has been completed. The Evaluation Activities for these two cases differ. </note>
             <aactivity>
               <TSS> The evaluator shall review the TSS to determine that a REK is supported by the
                 TOE, that the TSS includes a description of the protection provided by the TOE for a
@@ -1816,8 +1816,8 @@ How is it differenet then me using subsection?
                     instance of the RBG is used for REK(s).</htm:li>
                   <htm:li>If REK(s) is/are generated off-device, the TSS shall include evidence that
                     the RBG meets FCS_RBG_EXT.1. This will likely necessitate a second set of RBG
-                    documentation equivalent to the documentation provided for the RBG assurance
-                    activities. In addition, the TSS shall describe the manufacturing process that
+                    documentation equivalent to the documentation provided for the RBG Evaluation
+                    Activities. In addition, the TSS shall describe the manufacturing process that
                     prevents the device manufacturer from accessing any REK(s).</htm:li>
                 </htm:ul>
               </TSS>
@@ -2414,7 +2414,7 @@ How is it differenet then me using subsection?
                 procedure in terms of the memory in which the data are stored. <htm:br/><htm:br/>
               </TSS>
               <Tests>
-                <htm:b>Assurance Activity Note:</htm:b>The following tests require the developer to
+                <htm:b>Evaluation Activity Note:</htm:b>The following tests require the developer to
                 provide access to a test platform that provides the evaluator with tools that are
                 typically not found on factory products. <htm:br/><htm:br/> For each software and
                 firmware key clearing situation (including on system power off, on wipe function, on
@@ -2522,7 +2522,7 @@ How is it differenet then me using subsection?
                 The evaluator shall check to ensure the TSS describes how the device is wiped; and the type of clearing procedure that is performed (cryptographic erase or overwrite) and, if overwrite is performed, the overwrite procedure (overwrite with zeros, overwrite three or more times by a different alternating pattern, overwrite with random pattern, or block erase). If different types of memory are used to store the data to be protected, the evaluator shall check to ensure that the TSS describes the clearing procedure in terms of the memory in which the data are stored (for example, data stored on flash are cleared by overwriting once with zeros, while data stored on the internal persistent storage device are cleared by overwriting three times with a random pattern that is changed before each write). <htm:br/><htm:br/>
               </TSS>
               <Tests>
-                <htm:b>Assurance Activity Note:</htm:b> 
+                <htm:b>Evaluation Activity Note:</htm:b> 
                 The following test may require the developer to provide access to a test platform that provides the evaluator with tools that are typically not found on consumer Mobile Device products. <htm:br/><htm:br/> 
                 <testlist>
                   <test>The evaluator shall perform one of the following tests. The test before and after the wipe command shall be identical. This test shall be repeated for each type of memory used to store the data to be protected. <htm:br/><htm:br/>
@@ -2564,7 +2564,7 @@ How is it differenet then me using subsection?
               <TSS> The evaluator shall verify that the TSS contains a description regarding the
                 salt generation, including which algorithms on the TOE require salts. The evaluator
                 shall confirm that the salt is generated using an RBG described in FCS_RBG_EXT.1.
-                For PBKDF derivation of KEKs, this assurance activity may be performed in
+                For PBKDF derivation of KEKs, this Evaluation Activity may be performed in
                 conjunction with FCS_CKM_EXT.3.2. </TSS>
             </aactivity>
           </f-element>
@@ -2579,8 +2579,8 @@ How is it differenet then me using subsection?
               lack of a public/documented API for importing or exporting, when a
               private/undocumented API exists, is not sufficient to meet this requirement. </note>
             <aactivity>
-              <Tests>The assurance activity for this element is performed in conjunction with the
-                assurance activity for FCS_CKM_EXT.1. </Tests>
+              <Tests>The Evaluation Activity for this element is performed in conjunction with the
+                Evaluation Activity for FCS_CKM_EXT.1. </Tests>
             </aactivity>
           </f-element>
         </f-component>
@@ -2610,7 +2610,7 @@ How is it differenet then me using subsection?
             </note>
             <aactivity>
               <Tests>
-                <htm:b>Assurance Activity Note:</htm:b> The following tests require the developer to
+                <htm:b>Evaluation Activity Note:</htm:b> The following tests require the developer to
                 provide access to a test platform that provides the evaluator with tools that are
                 typically not found on factory products. <htm:br/><htm:br/>
                 <testlist><htm:b><htm:u>AES-CBC Tests</htm:u></htm:b>
@@ -2896,7 +2896,7 @@ How is it differenet then me using subsection?
                 sizes is present.<htm:br/><htm:br/>
               </Guidance>
               <Tests>
-                <htm:b>Assurance Activity Note:</htm:b> The following tests require the developer to
+                <htm:b>Evaluation Activity Note:</htm:b> The following tests require the developer to
                 provide access to a test platform that provides the evaluator with tools that are
                 typically not found on factory products. <htm:br/><htm:br/> The evaluator shall
                 perform all of the following tests for each hash algorithm implemented by the TSF
@@ -2966,7 +2966,7 @@ How is it differenet then me using subsection?
               that are implemented for that algorithm. </note>
             <aactivity>
               <Tests>
-                <htm:b>Assurance Activity Note:</htm:b> The following tests require the developer to
+                <htm:b>Evaluation Activity Note:</htm:b> The following tests require the developer to
                 provide access to a test platform that provides the evaluator with tools that are
                 typically not found on factory products. <htm:br/><htm:br/>
                 <testlist>
@@ -3038,7 +3038,7 @@ How is it differenet then me using subsection?
                 values used by the HMAC function: key length, hash function used, block size, and
                 output MAC length used. <htm:br/><htm:br/></TSS>
               <Tests>
-                <htm:b>Assurance Activity Note:</htm:b> The following tests require the developer to
+                <htm:b>Evaluation Activity Note:</htm:b> The following tests require the developer to
                 provide access to a test platform that provides the evaluator with tools that are
                 typically not found on factory products. <htm:br/><htm:br/> For each of the
                 supported parameter sets, the evaluator shall compose 15 sets of test data. Each set
@@ -3231,7 +3231,7 @@ How is it differenet then me using subsection?
                 appropriate instructions for configuring the RNG functionality.<htm:br/><htm:br/>
               </Guidance>
               <Tests>
-                <htm:b>Assurance Activity Note:</htm:b> The following tests require the developer to
+                <htm:b>Evaluation Activity Note:</htm:b> The following tests require the developer to
                 provide access to a test platform that provides the evaluator with tools that are
                 typically not found on factory products. <htm:br/><htm:br/> The evaluator shall
                 perform 15 trials for the RNG implementation. If the RNG is configurable, the
@@ -3361,7 +3361,7 @@ How is it differenet then me using subsection?
                 application that requests cryptographic operations by the TSF. The evaluator shall
                 verify that the results from the operation match the expected results according to
                 the API documentation. This application may be used to assist in verifying the
-                cryptographic operation assurance activities for the other algorithm services
+                cryptographic operation Evaluation Activities for the other algorithm services
                 requirements. </Tests>
             </aactivity>
           </f-element>
@@ -3382,7 +3382,7 @@ How is it differenet then me using subsection?
                 application that requests cryptographic operations of stored keys by the TSF. The
                 evaluator shall verify that the results from the operation match the expected
                 results according to the API documentation. The evaluator shall use these APIs to
-                test the functionality of the secure key storage according to the Assurance
+                test the functionality of the secure key storage according to the Evaluation
                 Activities in FCS_STG_EXT.1. </Tests>
             </aactivity>
           </f-element>
@@ -3663,7 +3663,7 @@ How is it differenet then me using subsection?
                 stored. It is not expected that a single key will be protected from corruption by
                 multiple of these methods; however, a product may use one integrity-protection method
                 for one type of key and a different method for other types of keys. The explicit
-                Assurance Activities for each of the options will be addressed in each of the
+                Evaluation Activities for each of the options will be addressed in each of the
                 requirements (FCS_COP.1.1/HASH, FCS_COP.1.1/KEYHMAC). <htm:br/><htm:br/> Key Wrapping
                 shall be implemented per SP800-38F.<htm:br/><htm:br/> The documentation of the
                 product's encryption key management should be detailed enough that, after reading, the
@@ -3724,7 +3724,7 @@ How is it differenet then me using subsection?
                 <htm:br/><htm:br/>
               </TSS>
               <Tests>
-                <htm:b>Assurance Activity Note:</htm:b> The following tests require the vendor to
+                <htm:b>Evaluation Activity Note:</htm:b> The following tests require the vendor to
                 provide access to a test platform that provides the evaluator with tools that are
                 typically not found on consumer Mobile Device products. <htm:br/><htm:br/> The
                 evaluator shall write, or the developer shall provide, applications for the purposes
@@ -3845,7 +3845,7 @@ How is it differenet then me using subsection?
               </selectables>.</title>
             <aactivity>
               <Tests>
-                <htm:b>Assurance Activity Note:</htm:b> The following tests require the developer to
+                <htm:b>Evaluation Activity Note:</htm:b> The following tests require the developer to
                 provide access to a test platform that provides the evaluator with tools that are
                 typically not found on consumer Mobile Device products.<htm:br/><htm:br/>
                 <testlist>
@@ -3965,7 +3965,7 @@ How is it differenet then me using subsection?
                 <htm:br/><htm:br/>
               </Guidance>
               <Tests>
-                <htm:b>Assurance Activity Note:</htm:b> The following test requires the developer to
+                <htm:b>Evaluation Activity Note:</htm:b> The following test requires the developer to
                 provide access to a test platform that provides the evaluator with tools that are
                 typically not found on consumer Mobile Device products. <htm:br/><htm:br/>
                 <testlist>
@@ -4263,14 +4263,14 @@ How is it differenet then me using subsection?
                 applications.<htm:br/><htm:br/>
               </Guidance>
               <Tests>
-                <htm:b>Assurance Activity Note:</htm:b> The following test requires the developer to
+                <htm:b>Evaluation Activity Note:</htm:b> The following test requires the developer to
                 provide access to a test platform that provides the evaluator with tools that are
                 typically not found on consumer Mobile Device products. <htm:br/><htm:br/> The
                 evaluator shall write, or the developer shall provide access to, an application that
                 requests protected channel services by the TSF. The evaluator shall verify that the
                 results from the protected channel match the expected results according to the API
                 documentation. This application may be used to assist in verifying the protected
-                channel assurance activities for the protocol requirements. The evaluator shall also
+                channel Evaluation Activities for the protocol requirements. The evaluator shall also
                 perform the following tests: <testlist>
                   <test>The evaluators shall ensure that the application is able to initiate
                     communications with an external IT entity using each protocol specified in the
@@ -4327,14 +4327,14 @@ How is it differenet then me using subsection?
                 applications.<htm:br/><htm:br/>
               </Guidance>
               <Tests>
-                <htm:b>Assurance Activity Note:</htm:b> The following test requires the developer to
+                <htm:b>Evaluation Activity Note:</htm:b> The following test requires the developer to
                 provide access to a test platform that provides the evaluator with tools that are
                 typically not found on consumer Mobile Device products. <htm:br/><htm:br/> The
                 evaluator shall write, or the developer shall provide access to, an application that
                 requests protected channel services by the TSF. The evaluator shall verify that the
                 results from the protected channel match the expected results according to the API
                 documentation. This application may be used to assist in verifying the protected
-                channel assurance activities for the protocol requirements. The evaluator shall also
+                channel Evaluation Activities for the protocol requirements. The evaluator shall also
                 perform the following tests: <testlist>
                   <test>The evaluators shall ensure that the application is able to initiate
                     communications with an external IT entity using each protocol specified in the
@@ -4774,9 +4774,9 @@ How is it differenet then me using subsection?
                 evaluation of presentation attack detection for biometrics <cite linkend="ISO19989"
                 /> is to be used to determine the efficacy of the PAD for the selected attack
                 potential. <htm:br/><htm:br/>
-                <htm:b>Assurance Activity Note:</htm:b> ISO 19989 is in draft status at the time of
+                <htm:b>Evaluation Activity Note:</htm:b> ISO 19989 is in draft status at the time of
                 publication of this PP. Once the ISO standard is published, it shall be used to meet
-                the assurance activity for this requirement. Henniger, Scheuermann, and Kniess <cite
+                the Evaluation Activity for this requirement. Henniger, Scheuermann, and Kniess <cite
                   linkend="IBPC"/>, provide a description of attack potential calculation with
                 examples. Until such time as ISO 19989 is published, the vendor shall provide to the
                 lab a description of the PAD processing implemented in the TSF, test procedures used
@@ -5063,7 +5063,7 @@ How is it differenet then me using subsection?
                 FCS_STG_EXT.2. <htm:br/><htm:br/></TSS>
               <Tests> The following tests may be performed in conjunction with FDP_DAR_EXT.1 and
                 FDP_DAR_EXT.2. <htm:br/><htm:br/>
-                <htm:b>Assurance Activity Note:</htm:b> The following test require the developer to
+                <htm:b>Evaluation Activity Note:</htm:b> The following test require the developer to
                 provide access to a test platform that provides the evaluator with tools that are
                 typically not found on consumer Mobile Device products. <htm:br/><htm:br/>
                 <testlist>
@@ -5140,7 +5140,7 @@ How is it differenet then me using subsection?
               is a separate authentication, to separate user and Enterprise applications and
               resources. </note>
             <aactivity>
-              <Tests>The assurance activities for any selected requirements related to device
+              <Tests>The Evaluation Activities for any selected requirements related to device
                 authentication must be separately performed for the secondary authentication
                 mechanism (in addition to activities performed for the primary authentication
                 mechanism). The requirements are: FIA_UAU.6, FIA_PMG_EXT.1, FIA_TRT_EXT.1,
@@ -5227,7 +5227,7 @@ How is it differenet then me using subsection?
                 certificates takes place. The evaluator ensures the TSS also provides a description
                 of the certificate path validation algorithm. <htm:br/><htm:br/></TSS>
               <Tests> The tests described must be performed in conjunction with the other
-                Certificate Services assurance activities, including the use cases in
+                Certificate Services Evaluation Activities, including the use cases in
                 FIA_X509_EXT.2.1 and FIA_X509_EXT.3. The tests for the extendedKeyUsage rules are
                 performed in conjunction with the uses that require those rules. The evaluator shall
                 create a chain of at least four certificates: the node certificate to be tested, two
@@ -5423,7 +5423,7 @@ How is it differenet then me using subsection?
                 instructions on requesting certificates from an EST server, including generating a
                 Certificate Request Message.<htm:br/><htm:br/></Guidance>
               <Tests> The evaluator shall also perform the following tests. Other tests are
-                performed in conjunction with the Assurance Activity listed in the Package for
+                performed in conjunction with the Evaluation Activity listed in the Package for
                 Transport Layer Security.<htm:br/>
                 <testlist>
                   <test>The evaluator shall use the operational guidance to cause the TOE to request
@@ -6237,9 +6237,9 @@ How is it differenet then me using subsection?
                 role(s) can perform each function, and how these functions are (or can be)
                 restricted to the roles identified by FMT_MOF_EXT.1. <htm:br/><htm:br/> The
                 following activities are organized according to the function number in the table.
-                These activities include TSS assurance activities, AGD assurance activities, and
+                These activities include TSS Evaluation Activities, AGD Evaluation Activities, and
                 test activities. <htm:br/><htm:br/> Test activities specified below shall take place
-                in the test environment described in the Assurance Activity for FPT_TUD_EXT.1.1,
+                in the test environment described in the Evaluation Activity for FPT_TUD_EXT.1.1,
                 FPT_TUD_EXT.1.2, and FPT_TUD_EXT.1.3. </TSS>
               <Guidance> The evaluator shall consult the AGD guidance to perform each of the
                 specified tests, iterating each test as necessary if both the user and administrator
@@ -6387,7 +6387,7 @@ How is it differenet then me using subsection?
                   <test>The evaluator shall use the test environment to instruct the TSF, both as a
                     user and as the administrator, to command the device to perform a wipe of
                     protected data. The evaluator must ensure that this management setup is used
-                    when conducting the assurance activities in FCS_CKM_EXT.5.</test><htm:br/>
+                    when conducting the Evaluation Activities in FCS_CKM_EXT.5.</test><htm:br/>
                   <htm:b>Function <ctr-ref refid="appInstallRules"/></htm:b><htm:br/> The evaluator
                   shall verify the TSS describes the allowable application installation policy
                   options based on the selection included in the ST. If the application whitelist is
@@ -6444,8 +6444,8 @@ How is it differenet then me using subsection?
                   applications) can be removed along with what role can do so. The evaluator shall
                   examine the AGD guidance to determine that it details, for each type of
                   application that can be removed, the procedures necessary to remove those
-                  applications and their associated data. For the purposes of this assurance
-                  activity, "associated data" refers to data that are created by the app during its
+                  applications and their associated data. For the purposes of this Evaluation
+                  Activity, "associated data" refers to data that are created by the app during its
                   operation that do not exist independent of the app's existence, for instance,
                   configuration data, or e-mail information that’s part of an e-mail client. It does
                   not, on the other hand, refer to data such as word processing documents (for a
@@ -6478,13 +6478,13 @@ How is it differenet then me using subsection?
                   <test>The evaluator shall exercise the TSF configuration as the administrator and,
                     if not restricted to the administrator, the user, to enable system-wide
                     data-at-rest protection according to the AGD guidance. The evaluator shall
-                    ensure that all assurance activities for DAR (FDP_DAR) are conducted with the
+                    ensure that all Evaluation Activities for DAR (FDP_DAR) are conducted with the
                     device in this configuration. </test><htm:br/>
                   <htm:b>Function <ctr-ref refid="rmediaDar"/></htm:b><htm:br/>
                   <test>The evaluator shall exercise the TSF configuration as the administrator and,
                     if not restricted to the administrator, the user, to enable removable media’s
                     data-at-rest protection according to the AGD guidance. The evaluator shall
-                    ensure that all assurance activities for DAR (FDP_DAR) are conducted with the
+                    ensure that all Evaluation Activities for DAR (FDP_DAR) are conducted with the
                     device in this configuration. </test><htm:br/>
                   <htm:b>Function <ctr-ref refid="location"/>
                   </htm:b><htm:br/>
@@ -6527,11 +6527,11 @@ How is it differenet then me using subsection?
                     </htm:ol>
                   </test><htm:br/>
                   <htm:br/>
-                  <htm:b>Assurance Activity Note:</htm:b> It should be noted that the following
+                  <htm:b>Evaluation Activity Note:</htm:b> It should be noted that the following
                   functions are optional capabilities, if the function is implemented, then the
-                  following assurance activities shall be performed. The notation of "[conditional]
+                  following Evaluation Activities shall be performed. The notation of "[conditional]
                   beside the function number indicates that if the function is not included in the
-                  ST, then there is no expectation that the assurance activity be performed. <htm:br/><htm:br/>
+                  ST, then there is no expectation that the Evaluation Activity be performed. <htm:br/><htm:br/>
                   <!-- TODO: Look AT -->
                   <htm:b>Function <ctr-ref refid="certInvalid"/> [conditional]</htm:b><htm:br/>
                   <test>The test of this function is performed in conjunction with FIA_X509_EXT.2.2,
@@ -6591,7 +6591,7 @@ How is it differenet then me using subsection?
                             application is not able to import the certificate. Failure of import
                             shall be tested by attempting to validate a certificate that chains to
                             the certificate whose import was attempted (as described in the
-                            Assurance Activity for FIA_X509_EXT.1). </htm:li>
+                            Evaluation Activity for FIA_X509_EXT.1). </htm:li>
                           <htm:li>The evaluator shall repeat the test, allowing the approval to
                             verify that the application is able to import the certificate and that
                             validation occurs. </htm:li>
@@ -6606,7 +6606,7 @@ How is it differenet then me using subsection?
                             application is not able to remove the certificate. Failure of removal
                             shall be tested by attempting to validate a certificate that chains to
                             the certificate whose removal was attempted (as described in the
-                            Assurance Activity for FIA_X509_EXT.1). </htm:li>
+                            Evaluation Activity for FIA_X509_EXT.1). </htm:li>
                         </htm:ul>
                       </htm:li>
                     </htm:ol> The evaluator shall repeat the test, allowing the approval to verify
@@ -6625,7 +6625,7 @@ How is it differenet then me using subsection?
                   <htm:b>Function <ctr-ref refid="auditLogs"/> [conditional]</htm:b><htm:br/>
                   <test>The evaluator shall attempt to read any device audit logs according to the
                     administrator guidance and verify that the logs may be read. This test may be
-                    performed in conjunction with the assurance activity of FAU_GEN.1. </test><htm:br/>
+                    performed in conjunction with the Evaluation Activity of FAU_GEN.1. </test><htm:br/>
                   <htm:b>Function <ctr-ref refid="digSign"/> [conditional]</htm:b><htm:br/>
                   <test>The test of this function is performed in conjunction with FPT_TUD_EXT.4.1. </test><htm:br/>
                   <htm:b>Function <ctr-ref refid="sharedKeys"/> [conditional]</htm:b><htm:br/> The
@@ -6717,7 +6717,7 @@ How is it differenet then me using subsection?
                   <htm:b>Function <ctr-ref refid="unenroll"/> [conditional]</htm:b><htm:br/>
                   <test>The evaluator shall attempt to unenroll the device from management and
                     verify that the steps described in FMT_SMF_EXT.2.1 are performed. This test
-                    should be performed in conjunction with the FMT_SMF_EXT.2.1 assurance activity. </test><htm:br/>
+                    should be performed in conjunction with the FMT_SMF_EXT.2.1 Evaluation Activity. </test><htm:br/>
                   <htm:b>Function <ctr-ref refid="alwaysOnVPN"/> [conditional]</htm:b><htm:br/>
                   <test>The evaluator shall verify that the TSS contains guidance to configure the
                     VPN as Always-On. The evaluator shall configure the VPN as Always-On and perform
@@ -6840,7 +6840,7 @@ How is it differenet then me using subsection?
               <TSS>The evaluator shall ensure that the TSS section of the ST describes how the 8
                 bits are generated and provides a justification as to why those bits are
                 unpredictable. <htm:br/><htm:br/>
-                <htm:b>Assurance Activity Note:</htm:b> The following test require the developer to
+                <htm:b>Evaluation Activity Note:</htm:b> The following test require the developer to
                 provide access to a test platform that provides the evaluator with tools that are
                 typically not found on consumer Mobile Device products. <htm:br/>
               </TSS>
@@ -6949,7 +6949,7 @@ How is it differenet then me using subsection?
                 prevent writing to files or flashing partitions. <htm:br/><htm:br/>
               </TSS>
               <Tests>
-                <htm:b>Assurance Activity Note:</htm:b> The following tests require the vendor to
+                <htm:b>Evaluation Activity Note:</htm:b> The following tests require the vendor to
                 provide access to a test platform that provides the evaluator with tools that are
                 typically not found on consumer Mobile Device products. In addition, the vendor
                 provides a list of files (e.g., system files, libraries, configuration files, audit
@@ -6990,7 +6990,7 @@ How is it differenet then me using subsection?
                 unpredictable. <htm:br/><htm:br/>
               </TSS>
               <Tests>
-                <htm:b>Assurance Activity Note:</htm:b> The following test require the developer to
+                <htm:b>Evaluation Activity Note:</htm:b> The following test require the developer to
                 provide access to a test platform that provides the evaluator with tools that are
                 typically not found on consumer Mobile Device products. <testlist>
                   <test>The evaluator shall reboot the TOE at least five times. For each of these
@@ -7152,7 +7152,7 @@ How is it differenet then me using subsection?
                 what has the access to the signing key.<htm:br/><htm:br/>
               </TSS>
               <Tests>
-                <htm:b>Assurance Activity Note:</htm:b> The following test requires the developer to
+                <htm:b>Evaluation Activity Note:</htm:b> The following test requires the developer to
                 provide access to a test platform that provides the evaluator with chip level
                 access. <htm:br/><htm:br/> If "disable access through hardware" is
                 selected:<htm:br/> The evaluator shall connect a packet analyzer to the JTAG ports.
@@ -7186,8 +7186,8 @@ How is it differenet then me using subsection?
               the keying material included for the BAF, mentioned in the previous paragraph, keying
               material also refers to the PIN/password used as part of the hybrid authentication. </note>
             <aactivity>
-              <TSS>The evaluator shall consult the TSS section of the ST in performing the assurance
-                activities for this requirement. <htm:br/><htm:br/> In performing their review, the
+              <TSS>The evaluator shall consult the TSS section of the ST in performing the Evaluation
+                Activities for this requirement. <htm:br/><htm:br/> In performing their review, the
                 evaluator shall determine that the TSS contains a description of the activities that
                 happen on power-up and password authentication relating to the decryption of DEKs,
                 stored keys, and data. <htm:br/><htm:br/> The evaluator shall ensure that the
@@ -7233,8 +7233,8 @@ How is it differenet then me using subsection?
               to provide cryptographic key operations (signature, encryption, and decryption) on
               behalf of applications (FCS_SRV_EXT.2.1) that have access to those keys. </note>
             <aactivity>
-              <TSS>The evaluator shall consult the TSS section of the ST in performing the assurance
-                activities for this requirement. The evaluator shall ensure that the TSS describes
+              <TSS>The evaluator shall consult the TSS section of the ST in performing the Evaluation
+                Activities for this requirement. The evaluator shall ensure that the TSS describes
                 the TOE security boundary. The cryptographic module may very well be a particular
                 kernel module, the Operating System, the Application Processor, or up to the entire
                 Mobile Device. <htm:br/><htm:br/> In performing their review, the evaluator shall
@@ -7297,7 +7297,7 @@ How is it differenet then me using subsection?
                 occur and the actions to be taken upon these critical failures.
                 <htm:br/><htm:br/></TSS>
               <Tests>
-                <htm:b>Assurance Activity Note:</htm:b> The following test require the developer to
+                <htm:b>Evaluation Activity Note:</htm:b> The following test require the developer to
                 provide access to a test platform that provides the evaluator with tools that are
                 typically not found on consumer Mobile Device products. <testlist>
                   <test>The evaluator shall use a tool provided by the developer to modify files and
@@ -7334,7 +7334,7 @@ How is it differenet then me using subsection?
                 in the device state. <htm:br/><htm:br/>
               </Guidance>
               <Tests>
-                <htm:b>Assurance Activity Note:</htm:b> The following test may require the developer
+                <htm:b>Evaluation Activity Note:</htm:b> The following test may require the developer
                 to provide access to a test platform that provides the evaluator with tools that are
                 typically not found on consumer Mobile Device products. <htm:br/><htm:br/> The
                 evaluator shall repeat the following test for each measurement: <testlist>
@@ -7457,7 +7457,7 @@ How is it differenet then me using subsection?
                 code through the kernel is verified before each execution. <htm:br/><htm:br/>
               </TSS>
               <Tests>
-                <htm:b>Assurance Activity Note:</htm:b> The following tests require the vendor to
+                <htm:b>Evaluation Activity Note:</htm:b> The following tests require the vendor to
                 provide access to a test platform that provides the evaluator with tools that are
                 typically not found on consumer Mobile Device products.<htm:br/><htm:br/> The
                 evaluator shall perform the following tests: <testlist>
@@ -7510,7 +7510,7 @@ How is it differenet then me using subsection?
               libraries) is verified, "all executable code stored in mutable media" should be
               selected. </note>
             <aactivity>
-              <Tests> The assurance activity shall be completed in conjunction with FPT_TST_EXT.2/PREKERNEL
+              <Tests> The Evaluation Activity shall be completed in conjunction with FPT_TST_EXT.2/PREKERNEL
                 for all executable code specified. </Tests>
             </aactivity>
           </f-element>
@@ -7525,8 +7525,8 @@ How is it differenet then me using subsection?
               ST. <htm:br/><htm:br/> Validity is determined by the certificate path, the expiration
               date, and the revocation status in accordance with RFC 5280. </note>
             <aactivity>
-              <Tests>Testing for this element is performed in conjunction with the assurance
-                activities for FPT_TST_EXT.2.1/PREKERNEL. </Tests>
+              <Tests>Testing for this element is performed in conjunction with the Evaluation
+                Activities for FPT_TST_EXT.2.1/PREKERNEL. </Tests>
             </aactivity>
           </f-element>
         </f-component>
@@ -7669,7 +7669,7 @@ How is it differenet then me using subsection?
               certificate validation. X.509v3 certificates and certificate validation are addressed
               in FPT_TUD_EXT.4.1.</note>
             <aactivity>
-              <htm:b>Assurance Activity Note:</htm:b> The following test does not have to be tested
+              <htm:b>Evaluation Activity Note:</htm:b> The following test does not have to be tested
               using the commercial application store. <htm:br/><htm:br/>
               <TSS>The evaluator shall verify that the TSS describes how mobile application software
                 is verified at installation. The evaluator shall ensure that this method uses a
@@ -7698,8 +7698,8 @@ How is it differenet then me using subsection?
               ST. <htm:br/><htm:br/> Validity is determined by the certificate path, the expiration
               date, and the revocation status in accordance with RFC 5280. </note>
             <aactivity>
-              <Tests>Testing for this element is performed in conjunction with the assurance
-                activities for FPT_TUD_EXT.2.3 and FPT_TUD_EXT.4.1. </Tests>
+              <Tests>Testing for this element is performed in conjunction with the Evaluation
+                Activities for FPT_TUD_EXT.2.3 and FPT_TUD_EXT.4.1. </Tests>
             </aactivity>
           </f-element>
         </f-component>
@@ -7729,7 +7729,7 @@ How is it differenet then me using subsection?
                     certificate and verify that application installation fails. The evaluator shall
                     digitally sign the application with a certificate that does not have the Code
                     Signing purpose and verify that application installation fails. This test may be
-                    performed in conjunction with the assurance activities for
+                    performed in conjunction with the Evaluation Activities for
                     FIA_X509_EXT.1.</test><htm:br/>
                   <test>If necessary, the evaluator shall configure the device to limit the public
                     keys that can sign application software according to the AGD guidance. The
@@ -7983,20 +7983,20 @@ How is it differenet then me using subsection?
       Requirements (SARs) to frame the extent to which the evaluator assesses the documentation
       applicable for the evaluation and performs independent testing.<htm:br/><htm:br/> This section
       lists the set of SARs from CC part 3 that are required in evaluations against this PP.
-      Individual Assurance Activities to be performed are specified both in <secref linkend="sfr"/>
+      Individual Evaluation Activities to be performed are specified both in <secref linkend="sfr"/>
       as well as in this section. <htm:br/><htm:br/> The general model for evaluation of TOEs
       against STs written to conform to this PP is as follows:<htm:br/><htm:br/> After the ST has
       been approved for evaluation, the <abbr class="expanded"
         title="Information Technology Security Evaluation Facility">ITSEF</abbr> will obtain the
       TOE, supporting environmental IT, and the administrative/user guides for the TOE. The ITSEF is
       expected to perform actions mandated by the Common Evaluation Methodology (CEM) for the ASE
-      and ALC SARs. The ITSEF also performs the Assurance Activities contained within <secref
-        linkend="sfr"/>, which are intended to be an interpretation of the other CEM assurance
-      requirements as they apply to the specific technology instantiated in the TOE. The Assurance
+      and ALC SARs. The ITSEF also performs the Evaluation Activities contained within <secref
+        linkend="sfr"/>, which are intended to be an interpretation of the other CEM evaluation
+      requirements as they apply to the specific technology instantiated in the TOE. The Evaluation
       Activities that are captured in <secref linkend="sfr"/> also provide clarification as to what
       the developer needs to provide to demonstrate the TOE is compliant with the PP.
       <htm:br/><htm:br/> 
-      The TOE security assurance requirements are identified in <ctr-ref refid="sartable"/>. 
+      The TOE Security Assurance Requirements are identified in <ctr-ref refid="sartable"/>. 
       <ctr id="sartable" ctr-type="Table">: Security Assurance Requirements</ctr>
       <htm:table>
         <htm:tr class="header">
@@ -8039,7 +8039,7 @@ How is it differenet then me using subsection?
       </htm:table>
       <subsection id="ase" title="Class ASE: Security Target"> The ST is evaluated as per ASE
         activities defined in the CEM for ASE_CCL.1, ASE_ECD.1, ASE_INT.1, ASE_OBJ.2, ASE_REQ.2,
-        ASE_SPD.1, and ASE_TSS.1. In addition, there may be Assurance Activities specified within
+        ASE_SPD.1, and ASE_TSS.1. In addition, there may be Evaluation Activities specified within
           <secref linkend="sfr"/> that call for necessary descriptions to be included in the TSS
         that are specific to the TOE technology type.</subsection>
       <subsection id="adv" title="Class ADV: Development"> The design information about the TOE is
@@ -8395,7 +8395,7 @@ How is it differenet then me using subsection?
             the administrative (including configuration and operational) documentation provided. The
             focus of the testing is to confirm that the requirements specified in <secref
               linkend="sfr"/> being met, although some additional testing is specified for SARs in
-              <secref linkend="sar"/>. The Assurance Activities identify the additional testing
+              <secref linkend="sar"/>. The Evaluation Activities identify the additional testing
             activities associated with these components. The evaluator produces a test report
             documenting the plan for and results of testing, as well as coverage arguments focused
             on the platform/TOE combinations that are claiming conformance to this PP. </summary>
@@ -8414,8 +8414,8 @@ How is it differenet then me using subsection?
               specified.</title>
             <aactivity>The evaluator shall prepare a test plan and report documenting the testing
               aspects of the system. The test plan covers all of the testing actions contained in
-              the <cite linkend="CEM"/> and the body of this PP’s Assurance Activities. While it is
-              not necessary to have one test case per test listed in an Assurance Activity, the
+              the <cite linkend="CEM"/> and the body of this PP’s Evaluation Activities. While it is
+              not necessary to have one test case per test listed in an Evaluation Activity, the
               evaluator must document in the test plan that each applicable testing requirement in
               the ST is covered. <htm:br/><htm:br/> The test plan identifies the platforms to be
               tested, and for those platforms not included in the test plan but included in the ST,


### PR DESCRIPTION
This is a replacement of Assurance Activities to Evaluation Activities. I tried to go through the whole document to catch them all (but not as a blanket change).

It is also always capitalized in this edit, regardless of where it is.