### PR TITLE
typo, remove 's

### DIFF
--- a/input/mobile-device.xml
+++ b/input/mobile-device.xml
@@ -3473,7 +3473,7 @@ How is it differenet then me using subsection?
                 destruction) described in these requirements. The API documentation shall include the
                 method by which applications restrict access to their keys/secrets in order to meet
                 FCS_STG_EXT.1.4". <htm:br/><htm:br/>
-                <TSS> The evaluator shall review the TSS to determine that the TOE’s implements the
+                <TSS> The evaluator shall review the TSS to determine that the TOE implements the
                   required secure key storage. The evaluator shall ensure that the TSS contains a
                   description of the key storage mechanism that justifies the selection of "mutable
                   hardware" or "software-based". <htm:br/><htm:br/>


### PR DESCRIPTION
Sentence doesn't read correctly. Looks like it was copied from other places with "TOE's implementation" but then became "TOE's implements".