### PR TITLE
Remove GPS for just location

### DIFF
--- a/input/mobile-device.xml
+++ b/input/mobile-device.xml
@@ -3691,7 +3691,7 @@ How is it differenet then me using subsection?
               include: <htm:br/><htm:br/>
               <htm:ul>
                 <htm:li>obtain data from camera and microphone input devices</htm:li>
-                <htm:li>retrieve current device location</htm:li>
+                <htm:li>obtain current device location</htm:li>
                 <htm:li>retrieve credentials from system-wide credential store</htm:li>
                 <htm:li>retrieve contacts list / address book</htm:li>
                 <htm:li>retrieve stored pictures</htm:li>

--- a/input/mobile-device.xml
+++ b/input/mobile-device.xml
@@ -3691,7 +3691,7 @@ How is it differenet then me using subsection?
               include: <htm:br/><htm:br/>
               <htm:ul>
                 <htm:li>obtain data from camera and microphone input devices</htm:li>
-                <htm:li>get current GPS location</htm:li>
+                <htm:li>retrieve current device location</htm:li>
                 <htm:li>retrieve credentials from system-wide credential store</htm:li>
                 <htm:li>retrieve contacts list / address book</htm:li>
                 <htm:li>retrieve stored pictures</htm:li>


### PR DESCRIPTION
Many devices today are using more than just the GPS for location (Wi-Fi, Cellular, even BT). 

I think it should instead just say to retrieve the current location since that would cover the broader set of services that make up the location services on the device and not just whether or not GPS is enabled.