### PR TITLE
remove conditional about VPN

### DIFF
--- a/input/mobile-device.xml
+++ b/input/mobile-device.xml
@@ -7957,10 +7957,10 @@ How is it differenet then me using subsection?
                   <test>The evaluator shall ensure, for each communication channel with an
                     authorized IT entity, the channel data are not sent in plaintext and that a
                     protocol analyzer identifies the traffic as the protocol under testing.</test><htm:br/>
-                  <test>[conditional] If IPsec is selected (and the TSF includes a native VPN
-                    client), the evaluator shall ensure that the TOE is able to initiate
-                    communications with a VPN Gateway, setting up the connections as described in
-                    the operational guidance and ensuring that communication is successful.</test><htm:br/>
+                  <test>[conditional] If IPsec is selected, the evaluator shall ensure that the TOE 
+                    is able to initiate communications with a VPN Gateway, setting up the 
+                    connections as described in the operational guidance and ensuring that 
+                    communication is successful.</test><htm:br/>
                   <test>[conditional]If OTA updates are selected, the evaluator shall trigger an
                     update request according to the operational guidance and shall ensure that the
                     communication is successful.</test><htm:br/>


### PR DESCRIPTION
Removed " (and the TSF includes a native VPN client)" as this is redundant based on the requirement that if you select IPsec that you MUST have an IPsec client included in the TOE