### PR TITLE
Move FDP_ACF_EXT.1.1 assurance activity to correct section

### DIFF
--- a/input/mobile-device.xml
+++ b/input/mobile-device.xml
@@ -7463,11 +7463,13 @@ The scope of this Protection Profile (PP) is to describe the security functional
                 applications from accessing those services. <h:br/><h:br/> For any services for
                 which the user may grant access, the evaluator shall ensure that the TSS identifies
                 whether the user is prompted for authorization when the application is installed, or
-                during runtime. The evaluator shall ensure that the operational user guidance
-                contains instructions for restricting application access to system services.
+                during runtime.
                 <h:br/><h:br/>
               </TSS>
-              <Guidance>There are no guidance evaluation activities for this element.<h:br/><h:br/></Guidance>
+              <Guidance>The evaluator shall ensure that the operational user guidance
+                contains instructions for restricting application access to system services.
+				<h:br/><h:br/>
+			  </Guidance>
               <Tests>
                 <h:b>Evaluation Activity Note:</h:b> The following tests require the vendor to
                 provide access to a test platform that provides the evaluator with tools that are


### PR DESCRIPTION
This assurance activity should be under guidance, as it requires the evaluator to inspect the operational user guidance.